### PR TITLE
Remove Chrome Beta Sauce Labs launcher

### DIFF
--- a/launchers.json
+++ b/launchers.json
@@ -3,11 +3,6 @@
     "base": "SauceLabs",
     "browserName": "chrome"
   },
-  "SL_ChromeBeta": {
-    "base": "SauceLabs",
-    "browserName": "chrome",
-    "version": "beta"
-  },
   "SL_ChromeDev": {
     "base": "SauceLabs",
     "browserName": "chrome",


### PR DESCRIPTION
This launcher doesn't seem to exist anymore. We constantly get:

  Can not start chrome beta
  Error response status: 6 Selenium error: no such session
