### PR TITLE
Remove Chrome Dev Sauce Labs launcher

### DIFF
--- a/launchers.json
+++ b/launchers.json
@@ -3,11 +3,6 @@
     "base": "SauceLabs",
     "browserName": "chrome"
   },
-  "SL_ChromeDev": {
-    "base": "SauceLabs",
-    "browserName": "chrome",
-    "version": "dev"
-  },
   "SL_IE10": {
     "base": "SauceLabs",
     "browserName": "internet explorer",


### PR DESCRIPTION
This launcher doesn't seem to exist anymore. We constantly get:

  Can not start chrome dev
  Error response status: 6 Selenium error: no such session
