### PR TITLE
Remove Firefox Dev Sauce Labs launcher

### DIFF
--- a/launchers.json
+++ b/launchers.json
@@ -25,11 +25,6 @@
     "base": "SauceLabs",
     "browserName": "firefox"
   },
-  "SL_FireFoxDev": {
-    "base": "SauceLabs",
-    "browserName": "firefox",
-    "version": "dev"
-  },
   "SL_Safari7": {
     "base": "SauceLabs",
     "browserName": "safari",


### PR DESCRIPTION
This launcher doesn't seem to exist anymore. We constantly get:

  Can not start firefox dev
  Error response status: 6 Selenium error: no such session
