### PR TITLE
Remove opera from saucelabs browser list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+- Remove opera from the Sauce Labs Launcher (seems now unsupported)
+
 ## [2.0.0] - 2017-08-02
 
 ### Breaking

--- a/launchers.json
+++ b/launchers.json
@@ -43,12 +43,6 @@
     "version": "latest"
   },
 
-  "SL_opera": {
-    "base": "SauceLabs",
-    "browserName": "opera",
-    "version": "latest"
-  },
-
   "SL_Android6.0": {
     "base": "SauceLabs",
     "browserName": "android",


### PR DESCRIPTION
Quite a few of our modules get automatically tested against various browsers. One of these is Opera, but it seems SauceLabs no longer supports it, which is why the resin-errors build now fails: https://travis-ci.org/resin-io-modules/resin-errors/jobs/300222098.

This PR stops us testing against it entirely, since there's not much other choice I think, and I strongly suspect it won't make any difference