### PR TITLE
Add headless Chrome parameters to work on ResinCi

### DIFF
--- a/karma.js
+++ b/karma.js
@@ -126,7 +126,15 @@ module.exports = function configure(packageJSON, overrides) {
     port: 9876,
     colors: true,
     autoWatch: false,
-    browsers: [ 'ChromeHeadless' ],
+    browsers: ['ChromeHeadlessCustom'],
+    customLaunchers: {
+      ChromeHeadlessCustom: {
+        base: 'ChromeHeadless',
+        flags: [
+          '--no-sandbox'
+        ]
+      }
+    },
     singleRun: true,
     concurrency: Infinity,
 


### PR DESCRIPTION
Change-type: minor
See: https://github.com/resin-io/resin-concourse/pull/248/
See: https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#running-on-alpine
Signed-off-by: Thodoris Greasidis <thodoris@resin.io>